### PR TITLE
Add support for relative URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ import "@alaskaairux/ods-hyperlink/dist/auro-hyperlink";
 <auro-hyperlink>Hello World!</auro-hyperlink>
 ```
 
-## Element ods-hyperlink
+## Element ods-hyperlink / auro-hyperlink
 
 ### hyperlink use cases
 
@@ -69,6 +69,12 @@ The `<ods-hyperlink>` or `<auro-hyperlink>` elements should be used in situation
 * inline link element for navigation
 * optional role as button when hyperlink UI is needed for submit action
 * optional role as tab when hyperlink UI is needed for a tablist
+
+### Auto URL re-write feature (auro only)
+
+Auro-hyperlink, by default, will re-write your URL to ensure that the domain is `https://www.alaskaair.com`. This feature also ensures that JavaScript URLs are also not passed in. 
+
+If a relative URL is required, pass in the `relative` flag to disable the addition of the Alaska Airlines domain. The `relative` feature and `target="_blank"` cannot be used together. If the component has both attributes, the 
 
 ### Orion Properties:
 
@@ -97,6 +103,7 @@ The `<ods-hyperlink>` or `<auro-hyperlink>` elements should be used in situation
 | nav | boolean | Displays element as block element for use as navigation |
 | ondark | boolean | Specifies dark theme use of hyperlink |
 | rel | string | Specifies the relationship between the current document and the linked document |
+| relative | boolean | Add flag to disable auto URL re-write feature |
 | role | string | Use for aria roles; currently supports `button` for extended experiences |
 | target †† | string | Specifies where to open the linked document |
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -58,17 +58,31 @@
       <demo-snippet>
         <template>
             <p>See more about <auro-hyperlink href="http://www.alaskaair.com">Alaska Airlines</auro-hyperlink> in this link.</p>
-            <p>See more about <auro-hyperlink target="_blank" href="http://www.alaskaair.com">Alaska Airlines</auro-hyperlink> in this link.</p>
+            <p>See more about <auro-hyperlink target="_blank" href="//www.apple.com">Apple Computers</auro-hyperlink> in this link.</p>
           </template>
       </demo-snippet>
 
-      <p>auro-hyperlink only accepts urls and will convert them to https:// protocol. </p>
+      <p>auro-hyperlink automatically converts URLs to a full path using the https:// protocol.</p>
       <demo-snippet>
         <template>
             <p>See more about <auro-hyperlink href="/about">Alaska Airlines</auro-hyperlink> in this link. Link returned in the DOM with full path to AS.com and https:// protocol.</p>
             <p>See more about <auro-hyperlink href="http://www.alaskaair.com">Alaska Airlines</auro-hyperlink> in this link. Link returned to the DOM with https:// protocol. </p>
             <p>See more about <auro-hyperlink href="//www.alaskaair.com">Alaska Airlines</auro-hyperlink> in this link. Link returned to the DOM with https:// protocol. </p>
+          </template>
+      </demo-snippet>
+
+      <p>Javascript hrefs are fully ignored.</p>
+      <demo-snippet>
+        <template>
             <p>See more about <auro-hyperlink href="javascript:my_function();window.print();">Alaska Airlines</auro-hyperlink> in this link. The href attribute is not returned to the DOM.</p>
+          </template>
+      </demo-snippet>
+
+      <p>If a relative path is needed, pass in the <code>relative</code> flag. </p>
+      <demo-snippet>
+        <template>
+            <p>See more about <auro-hyperlink relative href="/about">Alaska Airlines</auro-hyperlink> in this link. </p>
+            <p>See more about <auro-hyperlink relative href="/about" target="_blank">Alaska Airlines</auro-hyperlink> in this link. </p>
           </template>
       </demo-snippet>
 

--- a/src/auro-hyperlink.js
+++ b/src/auro-hyperlink.js
@@ -42,7 +42,7 @@ class AuroHyperlink extends ComponentBase {
   }
 
   getMarkup() {
-    this.safeUri = this.safeUrl(this.href);
+    this.safeUri = this.safeUrl(this.href, this.relative);
 
     const classes = {
       'hyperlink': this.safeUri || this.role,
@@ -62,7 +62,7 @@ class AuroHyperlink extends ComponentBase {
         ?download="${this.download}"
         target="${ifDefined(this.target ? this.target : undefined)}"
         tabindex="${ifDefined(this.role === 'button' ? '0' : undefined)}"
-      ><slot></slot>${this.targetIcon(this.target)}</a>`
+      ><slot></slot>${this.targetIcon(this.target, this.relative)}</a>`
       : html`<slot></slot>`}
     `;
   }

--- a/src/component-base.js
+++ b/src/component-base.js
@@ -33,11 +33,12 @@ export default class ComponentBase extends LitElement {
       rel:              { type: String },
       role:             { type: String },
       target:           { type: String },
-      download:         { type: Boolean }
+      download:         { type: Boolean },
+      relative:         { type: Boolean }
     };
   }
 
-  safeUrl(href) {
+  safeUrl(href, relative) {
     if (href !== undefined) {
       const url = new URL(href, 'https://www.alaskaair.com');
 
@@ -45,9 +46,14 @@ export default class ComponentBase extends LitElement {
         return undefined;
       }
 
-      url.protocol = 'https:';
+      if (!relative) {
+        url.protocol = 'https:';
 
-      return url.href;
+        return url.href;
+
+      } else if (relative) {
+        return href;
+      }
 
     } else if (href === undefined) {
       return undefined;
@@ -56,8 +62,8 @@ export default class ComponentBase extends LitElement {
     return undefined;
   }
 
-  targetIcon(target) {
-    if (target === '_blank') {
+  targetIcon(target, relative) {
+    if (target === '_blank' && !relative) {
       return this.svg;
     }
 


### PR DESCRIPTION
# Alaska Airlines Pull Request

## Summary:

This pull request adds support for cases where the pre-defined URL is not wanted. Prior, if a href of `/about` was passed into the WC, it would be returned with `https://www.alaskaair.com/about`.

But there are times when the relative path is wanted over the absolute. To address this, a new feature of `relative` was created and fully documented. 

## Type of change:

Please delete options that are not relevant.

- [x] New capability 
- [ ] Revision of an existing capability
- [ ] Infrastructure change (automation, etc.)
- [ ] Other (please elaborate) 


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._ 

**Thank you for your submission!**<br>
-- Orion Design System Team
